### PR TITLE
fix(CQDG): #128 Put sensible default for letsencrypt certificate key …

### DIFF
--- a/letsencrypt/base/certificate.yml
+++ b/letsencrypt/base/certificate.yml
@@ -13,7 +13,7 @@ spec:
   privateKey:
     algorithm: __UNDEFINED__
     encoding: __UNDEFINED__
-    size: __UNDEFINED__
+    size: 4096
   usages:
     - server auth
     - client auth


### PR DESCRIPTION
…size to prevent silent kustomize type conversion when doing strategic merge patch