### PR TITLE
fix(CQDG): #128 Tentative fix for octal 0555 getting interpreted as n…

### DIFF
--- a/zeppelin/template-override.yml
+++ b/zeppelin/template-override.yml
@@ -101,7 +101,8 @@ data:
       - name: aggregate-configs
         configMap:
           name: zeppelin-spark-config-aggregate
-          defaultMode: 0555
+          #Numeric value of 0555
+          defaultMode: 365
       {% endif %}
     ---
     kind: Service


### PR DESCRIPTION
…umeric 555, probably by the templating engine zeppelin uses