### PR TITLE
feat: SJRA-1184 add polaris service templates

### DIFF
--- a/polaris/init/README.md
+++ b/polaris/init/README.md
@@ -1,0 +1,58 @@
+# Polaris initialization templates
+
+This folder provides templates for initializing resources on an existing Polaris server.
+
+The templates assume:
+- Authentication is handled via the internal token broker using symmetric key credentials (username and password).
+- All catalogs are stored on the same S3/MinIO account and share a common S3 endpoint.
+
+Initialization is performed in 3 steps, each managed by a separate container (two init containers and the main container).
+Configuration is provided via environment variables and configmap as described below.
+
+**Note**:
+While multiple realms are supported by this initialization process, not all polaris clients are compatible with multi-realm configurations. Please verify client compatibility before using multiple realms.
+
+
+## Step1 1: wait-for-polaris init container
+
+This step ensures that the polaris service is ready before proceeding.
+
+Set the following environment variable in the wait-for-polaris init container of the polaris-init-job:
+
+- `POLARIS_MGMT_SERVICE_URL`: The URL of the Polaris management service, used to verify service readiness. Defaults to `http://polaris-mgmt:8182`.
+
+## Step 2: bootstrap-realms init container
+
+In the `bootstrap-realms` init container of the `polaris-init-job`, add the following environment variables:
+
+- `QUARKUS_DATASOURCE_USERNAME`: Polaris database username
+- `QUARKUS_DATASOURCE_PASSWORD`: Polaris database password
+- `QUARKUS_DATASOURCE_JDBC_URL`: Polaris database JDBC URL (e.g., `jdbc:postgresql://my-db-host:5432/my-db-host`)
+- `POLARIS_REALM_NAMES`: Comma-separated list of realms to create (e.g., `realm1,realm2`)
+
+For each realm listed in `POLARIS_REALM_NAMES`, also add:
+- `POLARIS_REALM_<REALM NAME>_ROOT_USER`: Realm root principal username (polaris client ID)
+- `POLARIS_REALM_<REALM NAME>_ROOT_PASSWORD`: Realm root principal password (polaris client secret)
+
+## Step 3: init-polaris container
+
+Create a ConfigMap named `polaris-realm-config` with a key `realm-config.json`.
+
+This file will be mounted into the `polaris-init-job` container.  
+An example `realm-config.json` is provided in this folder.
+
+In `realm-config.json`, specify for each realm the catalogs, principals, roles, and namespaces to create.
+
+In the `init-polaris` container of the `polaris-init-job`, add the following environment variables:
+
+For each realm in your `realm-config.json`:
+- `POLARIS_REALM_<REALM NAME>_ROOT_USER`: Realm root principal username
+- `POLARIS_REALM_<REALM NAME>_ROOT_PASSWORD`: Realm root principal password
+
+For each principal to create (as specified in `realm-config.json`):
+- `POLARIS_REALM_<REALM NAME>_<PRINCIPAL NAME>_USER`: Principal username
+- `POLARIS_REALM_<REALM NAME>_<PRINCIPAL NAME>_PASSWORD`: Principal password
+  
+Finally, add:
+- `CATALOG_ENDPOINT`: S3 endpoint URL to use for the catalogs
+- `POLARIS_SERVICE_HOST`: host for the polaris service, default to `polaris:8181`

--- a/polaris/init/init-job.yml
+++ b/polaris/init/init-job.yml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: polaris-init-job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-polaris
+          image: curlimages/curl:8.7.1
+          env:
+            - name: POLARIS_MGMT_SERVICE_URL
+              value: "http://polaris-mgmt:8182"
+          command:
+            - /opt/scripts/wait-for-polaris.sh
+          volumeMounts:
+            - name: wait-for-polaris-script
+              mountPath: /opt/scripts
+
+        - name: bootstrap-realms
+          image: apache/polaris-admin-tool:1.3.0-incubating
+
+          command: ["/opt/scripts/bootstrap.sh"]
+          volumeMounts:
+            - name: bootstrap-script
+              mountPath: /opt/scripts
+
+      containers:
+        # Create catalog, users, roles, namespace, etc.
+        - name: polaris-init
+          image: ferlabcrsj/python-requests:0.1.0
+
+          env:
+            - name: POLARIS_SERVICE_HOST
+              value: polaris:8181
+        
+
+          command: ["python3", "/opt/scripts/init-script.py"]
+
+          volumeMounts:
+            - name: init-script
+              mountPath: /opt/scripts
+            - name: realm-config
+              mountPath: /opt/config
+      volumes:
+        - name: realm-config
+          configMap:
+            name: polaris-realm-config
+            defaultMode: 0555
+        - name: init-script
+          configMap:
+            name: polaris-init-script
+            defaultMode: 0555
+        - name: wait-for-polaris-script
+          configMap:
+            name: polaris-wait-ready-script
+            defaultMode: 0555
+        - name: bootstrap-script
+          configMap:
+            name: polaris-bootstrap-script
+            defaultMode: 0555

--- a/polaris/init/kustomization.yml
+++ b/polaris/init/kustomization.yml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+configMapGenerator:
+  - name: polaris-wait-ready-script
+    options:
+      disableNameSuffixHash: true
+    files:
+      - scripts/wait-for-polaris.sh
+  - name: polaris-init-script
+    options:
+      disableNameSuffixHash: true
+    files:
+      - scripts/init-script.py
+  - name: polaris-bootstrap-script
+    options:
+      disableNameSuffixHash: true
+    files:
+      - scripts/bootstrap.sh
+
+resources:
+  - init-job.yml

--- a/polaris/init/realm-config.json
+++ b/polaris/init/realm-config.json
@@ -1,0 +1,37 @@
+{
+  "realms": [
+    {
+      "name": "realm1",
+      "catalogs": [
+        {
+          "name": "catalog1",
+          "warehouse": "s3://warehouse-catalog-1",
+          "namespaces": ["ns1", "ns2"],
+          "catalog_roles": [
+            {
+              "name": "catalog_role1",
+              "privileges": ["CATALOG_MANAGE_CONTENT"]
+            }
+          ]
+        }
+      ],
+      "principal_roles": [
+        {
+          "name": "principal_roles1",
+          "catalog_roles": [
+            {
+              "name": "catalog_role1",
+              "catalog": "catalog1"
+            }
+          ]
+        }
+      ],
+      "principals": [
+        {
+          "name": "user1",
+          "principal_roles": ["principal_roles1"]
+        }
+      ]
+    }
+  ]
+}

--- a/polaris/init/scripts/bootstrap.sh
+++ b/polaris/init/scripts/bootstrap.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -euo pipefail
+
+: "${POLARIS_REALM_NAMES:?Environment variable POLARIS_REALM_NAMES is required (comma-separated)}"
+
+create_realm_if_not_exists() {
+  local realm="$1"
+  local client_id="$2"
+  local client_secret="$3"
+  
+  echo "Creating realm $realm"
+  local output=$(java -jar /deployments/polaris-admin-tool.jar bootstrap -r "$realm" -c "$realm,$client_id,$client_secret" -p 2>&1)
+  local status=$?
+  if echo "$output" | grep -q "It appears this metastore manager has already been bootstrapped"; then
+      echo "Realm already bootstrapped for realm ${realm}"
+  fi
+  if [ $status -ne 0 ]; then
+      echo "❌ Unexpected error during bootstrap"
+      echo "$output"
+      exit 1
+  fi
+  echo "Done creating realm $realm"
+}
+
+main() {
+  echo "create realms if not exists"
+  local realms
+  local users
+  local passwords
+  IFS=',' read -r -a realms <<< "$POLARIS_REALM_NAMES"
+
+  for idx in "${!realms[@]}"; do
+    local realm="${realms[$idx]}"
+    local realm_upper=$(echo "$realm" | tr '[:lower:]' '[:upper:]')
+    local env_user_var="POLARIS_REALM_${realm_upper}_ROOT_USER"
+    local env_password_var="POLARIS_REALM_${realm_upper}_ROOT_PASSWORD"
+    eval "client_id=\${$env_user_var}"
+    eval "client_secret=\${$env_password_var}"
+    if [ -z "$client_id" ] || [ -z "$client_secret" ]; then
+      echo "❌ Missing credentials for realm '$realm'. Expected env vars: $env_user_var and $env_password_var"
+      exit 1
+    fi
+    create_realm_if_not_exists "${realm}" "${client_id}" "${client_secret}"
+  done
+}
+
+main

--- a/polaris/init/scripts/init-script.py
+++ b/polaris/init/scripts/init-script.py
@@ -1,0 +1,224 @@
+import json
+import os
+import sys
+import requests
+
+
+CONFIG_PATH = "/opt/config/realm-config.json"
+POLARIS_SERVICE_HOST = os.environ["POLARIS_SERVICE_HOST"]
+CATALOG_ENDPOINT = os.environ["CATALOG_ENDPOINT"]
+
+def load_config(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def polaris_api(method, endpoint, realm, token, payload=None):
+    url = f"http://{POLARIS_SERVICE_HOST}/{endpoint}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Polaris-Realm": realm,
+        "Accept": "application/json"
+    }
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload)
+    else:
+        data = None
+
+    resp = requests.request(method, url, headers=headers, data=data)
+    if not resp.ok:
+        print(f"❌ API request failed for method '{method}' and url '{url}' with payload '{payload}'")
+        print(resp.text)
+        sys.exit(1)
+    return resp.json() if method in ["GET", "POST"] else resp.text
+
+
+def fetch_token(client_id, client_secret):
+    url = f"http://{POLARIS_SERVICE_HOST}/api/catalog/v1/oauth/tokens"
+    headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+    data = f"grant_type=client_credentials&client_id={client_id}&client_secret={client_secret}&scope=PRINCIPAL_ROLE:ALL"
+    resp = requests.post(url, headers=headers, data=data)
+    if not resp.ok:
+        print("❌ Failed to obtain access token")
+        print(resp.text)
+        sys.exit(1)
+    token = resp.json().get("access_token")
+    if not token:
+        print(f"❌ Failed to parse access token from response: {resp.text}")
+        sys.exit(1)
+    print("✅ Obtained access token")
+    return token
+
+
+def create_catalog_if_not_exists(realm, token, catalog_name, catalog_endpoint, catalog_warehouse):
+    payload = {
+        "catalog": {
+            "name": catalog_name,
+            "type": "INTERNAL",
+            "readOnly": False,
+            "properties": {
+                "default-base-location": catalog_warehouse
+            },
+            "storageConfigInfo": {
+                "storageType": "S3",
+                "allowedLocations": [catalog_warehouse],
+                "endpoint": catalog_endpoint,
+                "pathStyleAccess": True
+            }
+        }
+    }
+    catalogs = polaris_api("GET", "api/management/v1/catalogs", realm, token)
+    if any(c.get("name") == catalog_name for c in catalogs.get("catalogs", [])):
+        print(f"The catalog '{catalog_name}' already exists, skipping creation.")
+    else:
+        polaris_api("POST", "api/management/v1/catalogs", realm, token, payload)
+        print("✅ Catalog created")
+
+
+def create_namespace_if_not_exists(realm, token, catalog_name, namespace):
+    payload = {
+        "namespace": [namespace],
+        "properties": {}
+    }
+    namespaces = polaris_api("GET", f"api/catalog/v1/{catalog_name}/namespaces", realm, token)
+    if any( namespace in ns for ns in namespaces.get("namespaces", [])):
+        print(f"The namespace '{namespace}' already exists in catalog '{catalog_name}', skipping creation.")
+    else:
+        polaris_api("POST", f"api/catalog/v1/{catalog_name}/namespaces", realm, token, payload)
+        print("✅ Namespace created")
+
+
+def create_principal_if_not_exists(realm, token, principal_name):
+    payload = {
+        "principal": {
+            "name": principal_name,
+            "properties": {}
+        }
+    }
+    principals = polaris_api("GET", "api/management/v1/principals", realm, token)
+    if any(p.get("name") == principal_name for p in principals.get("principals", [])):
+        print(f"The principal '{principal_name}' already exists, skipping creation.")
+    else:
+        polaris_api("POST", "api/management/v1/principals", realm, token, payload)
+        print(f"✅ User '{principal_name}' created")
+
+
+def reset_principal_credentials(realm, token, principal_name, principal_user, principal_password):
+    payload = {
+        "clientId": principal_user,
+        "clientSecret": principal_password
+    }
+    polaris_api("POST", f"api/management/v1/principals/{principal_name}/reset", realm, token, payload)
+    print(f"✅ Credentials for principal '{principal_name}' reset")
+
+
+def create_catalog_role_if_not_exists(realm, token, catalog_name, role_name):
+    payload = {
+        "catalogRole": {
+            "name": role_name,
+            "properties": {}
+        }
+    }
+    roles = polaris_api("GET", f"api/management/v1/catalogs/{catalog_name}/catalog-roles", realm, token)
+    if any(r.get("name") == role_name for r in roles.get("roles", [])):
+        print(f"The catalog role '{role_name}' already exists, skipping creation.")
+    else:
+        polaris_api("POST", f"api/management/v1/catalogs/{catalog_name}/catalog-roles", realm, token, payload)
+        print("✅ Catalog role created")
+
+
+def create_principal_role_if_not_exists(realm, token, role_name):
+    payload = {
+        "principalRole": {
+            "name": role_name,
+            "properties": {}
+        }
+    }
+    roles = polaris_api("GET", "api/management/v1/principal-roles", realm, token)
+    if any(r.get("name") == role_name for r in roles.get("roles", [])):
+        print(f"The principal role '{role_name}' already exists, skipping creation.")
+    else:
+        polaris_api("POST", "api/management/v1/principal-roles", realm, token, payload)
+        print("✅ Principal role created")
+
+
+def assign_role_to_principal(realm, token, principal_name, role_name):
+    payload = {
+        "principalRole": {
+            "name": role_name,
+            "properties": {}
+        }
+    }
+    roles = polaris_api("GET", f"api/management/v1/principals/{principal_name}/principal-roles", realm, token)
+    if any(r.get("name") == role_name for r in roles.get("roles", [])):
+        print(f"The role '{role_name}' is already assigned to principal '{principal_name}', skipping assignment.")
+    else:
+        polaris_api("PUT", f"api/management/v1/principals/{principal_name}/principal-roles", realm, token, payload)
+        print(f"✅ Role '{role_name}' assigned to principal '{principal_name}'")
+
+
+def assign_catalog_role_to_principal_role(realm, token, catalog_name, catalog_role_name, principal_role_name):
+    payload = {
+        "catalogRole": {
+            "name": catalog_role_name
+        }
+    }
+    catalog_roles = polaris_api("GET", f"api/management/v1/principal-roles/{principal_role_name}/catalog-roles/{catalog_name}", realm, token)
+    if any(r.get("name") == catalog_role_name for r in catalog_roles.get("roles", [])):
+        print(f"The catalog role '{catalog_role_name}' is already assigned to principal role '{principal_role_name}', skipping assignment.")
+    else:
+        polaris_api("PUT", f"api/management/v1/principal-roles/{principal_role_name}/catalog-roles/{catalog_name}", realm, token, payload)
+        print(f"✅ Catalog role '{catalog_role_name}' assigned to principal role '{principal_role_name}' for catalog '{catalog_name}'")
+
+
+def grant_privilege_if_not_exists(realm, token, catalog_name, role_name, privilege):
+    payload = {"type": "catalog", "privilege": privilege}
+    grants = polaris_api("GET", f"api/management/v1/catalogs/{catalog_name}/catalog-roles/{role_name}/grants", realm, token)
+    if any(g.get("privilege") == privilege for g in grants.get("grants", [])):
+        print(f"The '{role_name}' role already has the '{privilege}' privilege on catalog '{catalog_name}', skipping grant.")
+    else:
+        polaris_api("PUT", f"api/management/v1/catalogs/{catalog_name}/catalog-roles/{role_name}/grants", realm, token, payload)
+        print(f"✅ Granted '{privilege}' privilege to '{role_name}' role on catalog '{catalog_name}'")
+
+
+def main():
+    config = load_config(CONFIG_PATH)
+
+
+    for realm in config.get("realms", []):
+        realm_name = realm['name']
+        print(f"Processing realm: {realm_name}")
+        realm_user = os.environ[f"POLARIS_REALM_{realm_name.upper()}_ROOT_USER"]
+        realm_password = os.environ[f"POLARIS_REALM_{realm_name.upper()}_ROOT_PASSWORD"]
+        token = fetch_token(realm_user, realm_password)
+
+        for catalog in realm.get("catalogs", []):
+            create_catalog_if_not_exists(realm_name, token, catalog["name"], CATALOG_ENDPOINT, catalog["warehouse"])
+            for ns in catalog.get("namespaces", []):
+                create_namespace_if_not_exists(realm_name, token, catalog["name"], ns)
+            for role in catalog.get("catalog_roles", []):
+                create_catalog_role_if_not_exists(realm_name, token, catalog["name"], role["name"])
+                for privilege in role.get("privileges", []):
+                    grant_privilege_if_not_exists(realm_name, token, catalog["name"], role["name"], privilege)
+
+        for principal_role in realm.get("principal_roles", []):
+            create_principal_role_if_not_exists(realm_name, token, principal_role['name'])
+            for catalog_role in principal_role['catalog_roles']:
+                assign_catalog_role_to_principal_role(realm_name, token, catalog_role['catalog'], catalog_role['name'], principal_role['name'])
+
+        for principal in realm.get("principals", []):
+            principal_name = principal["name"]
+            create_principal_if_not_exists(realm_name, token, principal_name)
+            principal_user = os.environ[f"POLARIS_REALM_{realm_name.upper()}_{principal_name.upper()}_USER"]
+            principal_password = os.environ[f"POLARIS_REALM_{realm_name.upper()}_{principal_name.upper()}_PASSWORD"]
+
+            reset_principal_credentials(realm_name, token, principal_name, principal_user, principal_password)
+            for principal_role in principal.get("principal_roles", []):
+                assign_role_to_principal(realm_name, token, principal_name, principal_role)
+
+        print(f"Done processing realm {realm_name}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/polaris/init/scripts/wait-for-polaris.sh
+++ b/polaris/init/scripts/wait-for-polaris.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -euo pipefail
+
+: "${POLARIS_MGMT_SERVICE_URL:? POLARIS_MGMT_SERVICE_URL environment variable is required}"
+
+
+echo "Waiting for Polaris to be available"
+
+until curl -sf $POLARIS_MGMT_SERVICE_URL/q/health/ready > /dev/null; do
+  echo "Polaris is not available yet. Retrying in 5 seconds..."
+  sleep 5
+done
+
+echo "Polaris is available. Proceeding with catalog initialization."

--- a/polaris/service/README.md
+++ b/polaris/service/README.md
@@ -1,0 +1,38 @@
+# Polaris Service Template
+
+This folder provides Kubernetes templates for deploying Polaris as a service.
+
+## Datasource configuration
+
+Polaris requires an SQL database (e.g., PostgreSQL, MySQL) to persist information.  
+Note: The database itself is not provisioned by these templates—you are responsible for creating and managing it.
+
+To connect polaris to your database, add the following environment variables to the `env` section of the `polaris` container in the deployment resource:
+- `QUARKUS_DATASOURCE_USERNAME`: Database username
+- `QUARKUS_DATASOURCE_PASSWORD`: Database password
+- `QUARKUS_DATASOURCE_JDBC_URL`: JDBC connection string (e.g., `jdbc:postgresql://your-db-host:5432/your-db-name`)
+
+## AWS configuration
+
+The templates assume data will be stored in S3 or MinIO.  
+Add the following environment variables to the `env` section of the `polaris` container in the `polaris` deployment resource:
+- AWS_REGION
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_KEY
+- AWS_ENDPOINT_URL
+
+
+## Authentication configuration and application.properties
+
+The polaris ConfigMap resource injects the application.properties file described in the Polaris documentation.
+ 
+You can use the provided configuration as is, or overwrite it downstream to suit your needs.
+By default, it assumes the use of the internal token broker with symmetric-key credentials (i.e., username and password) for authentication.
+
+To use this default setup, add the following environment variables to the env section of the polaris container in your deployment. These variables are referenced in the application.properties file:
+
+- `POLARIS_AUTHENTICATION_TOKEN_BROKER_SYMMETRIC_KEY_SECRET`: Password for the global Polaris cross-realm user.
+- `POLARIS_REALM_CONTEXT_REALMS`: Comma-separated list of realms to use.
+
+Warning:
+Not all Polaris clients support multiple realms. If you specify more than one realm in POLARIS_REALMS, ensure that all your clients are compatible with this configuration.

--- a/polaris/service/config.yml
+++ b/polaris/service/config.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: polaris
+  labels:
+    name: polaris
+data:
+  application.properties: |-
+    polaris.authentication.token-broker.max-token-generation=PT1H
+    polaris.authentication.token-broker.type=symmetric-key
+    polaris.features."ALLOW_SETTING_S3_ENDPOINTS"=true
+    polaris.features."SUPPORTED_CATALOG_STORAGE_TYPES"=["S3"]
+    polaris.persistence.type=relational-jdbc

--- a/polaris/service/deployment.yml
+++ b/polaris/service/deployment.yml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: polaris
+  labels:
+    app: polaris
+spec:
+  selector:
+    matchLabels:
+      app: polaris
+  template:
+    metadata:
+      labels:
+        app: polaris
+    
+    spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: polaris
+            items:
+              - key: application.properties
+                path: application.properties
+      
+      containers:
+        - name: polaris
+          resources:
+          image: apache/polaris:1.3.0-incubating
+          
+          ports:
+            - containerPort: 8181
+              name: polaris-http
+              protocol: TCP
+            - containerPort: 8182
+              name: polaris-mgmt
+              protocol: TCP
+          
+          volumeMounts:
+            - mountPath: /deployments/config
+              name: config-volume
+              readOnly: true
+          
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/live
+              port: polaris-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/ready
+              port: polaris-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10

--- a/polaris/service/kustomization.yml
+++ b/polaris/service/kustomization.yml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config.yml
+  - deployment.yml
+  - services.yml
+

--- a/polaris/service/services.yml
+++ b/polaris/service/services.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: polaris
+  labels:
+    app: polaris
+spec:
+  selector:
+    app: polaris
+  ports:
+    - port: 8181
+      targetPort: 8181
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: polaris-mgmt
+  labels:
+    app: polaris-mgmt
+spec:
+  selector:
+    app: polaris
+  ports:
+    - port: 8182
+      targetPort: 8182
+      protocol: TCP
+


### PR DESCRIPTION
## 📌 Context

This PR introduces reusable templates for the Polaris Iceberg catalog service and its associated initialization logic.

## 📝 Changes
- Added Polaris initialization templates in `polaris/init`
- Added Polaris service templates in `polaris/init`

## 🧪 Tests

Tested locally with Minikube using downstream kustomizations from this PR:
https://github.com/Ferlab-Ste-Justine/cqdg-pre-prod-kubernetes-environments/pull/386

The Polaris service was created successfully and the initialization logic executed correctly. Verified that the initialization logic can be run multiple times without issues.

## 🔗 Related Issues

Pre-requisite for this PR:
- https://github.com/Ferlab-Ste-Justine/cqdg-pre-prod-kubernetes-environments/pull/386


## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- 