### PR TITLE
feat: SJRA-1184 support no sts for polaris catalog

### DIFF
--- a/polaris/init/README.md
+++ b/polaris/init/README.md
@@ -4,7 +4,7 @@ This folder provides templates for initializing resources on an existing Polaris
 
 The templates assume:
 - Authentication is handled via the internal token broker using symmetric key credentials (username and password).
-- All catalogs are stored on the same S3/MinIO account and share a common S3 endpoint.
+- All catalogs are stored on the same S3/MinIO account
 
 Initialization is performed in 3 steps, each managed by a separate container (two init containers and the main container).
 Configuration is provided via environment variables and configmap as described below.
@@ -43,6 +43,11 @@ An example `realm-config.json` is provided in this folder.
 
 In `realm-config.json`, specify for each realm the catalogs, principals, roles, and namespaces to create.
 
+**Note**:
+The catalog stsUnavailable attribute in the example realm-config.json is optional.
+By default, if not specified, it will be set to false.
+You should set stsUnavailable to true if you are using an S3 backend that does not support the STS service, specifically the AssumeRole endpoint.
+
 In the `init-polaris` container of the `polaris-init-job`, add the following environment variables:
 
 For each realm in your `realm-config.json`:
@@ -54,5 +59,4 @@ For each principal to create (as specified in `realm-config.json`):
 - `POLARIS_REALM_<REALM NAME>_<PRINCIPAL NAME>_PASSWORD`: Principal password
   
 Finally, add:
-- `CATALOG_ENDPOINT`: S3 endpoint URL to use for the catalogs
 - `POLARIS_SERVICE_HOST`: host for the polaris service, default to `polaris:8181`

--- a/polaris/init/realm-config.json
+++ b/polaris/init/realm-config.json
@@ -7,6 +7,8 @@
           "name": "catalog1",
           "warehouse": "s3://warehouse-catalog-1",
           "namespaces": ["ns1", "ns2"],
+          "stsUnavailable": false,
+          "s3_endpoint": "http://minio:9000",
           "catalog_roles": [
             {
               "name": "catalog_role1",


### PR DESCRIPTION
## 📌 Context

This PR allows disabling STS for a specific Polaris catalog and enables specifying the S3 endpoint per catalog, rather than globally for all catalogs.

## 📝 Changes

<!-- List the main changes in this PR. -->
- Update the Polaris initialization script to support the stsUnavailable catalog property and extract the S3 endpoint from catalog properties
- Revise the example realm-config.json configuration file.
- Update the documentation in polaris/init/README.md

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->

- Need complementary PR + catalog cleanup procedure  in cqdg-pre-prod-kubernetes-environment: 
https://github.com/Ferlab-Ste-Justine/cqdg-pre-prod-kubernetes-environments/pull/391

## 🧪 Tests

**Check polaris init script functionality**:
Tested locally on Minikube using an overlay from the cqdg-pre-prod-kubernetes-environment branch. Verified that the catalog was created with the correct properties using a curl command. Tested stsUnavailable=false, stsUnavailable=true  and stsUnavailable missing scenarios.

**Check STS deactivation**:
Used the radiant-portal-sandbox to confirm that when stsUnavailable is set to true, no AssumeRole requests are sent to MinIO and the Spark initialization script can successfully write Iceberg tables. Also verified that when stsUnavailable is explicitly set to false, AssumeRole requests are sent (STS is used) and the Spark initialization script still works as expected.

## 🔗 Related Issues

<!-- Link to any relevant GitHub issues, Jira tickets, etc. -->

-

## 👀 Notes for Reviewers


<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- 